### PR TITLE
rollback package name to etcdserverpb

### DIFF
--- a/src/main/proto/rpc.proto
+++ b/src/main/proto/rpc.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "kv.proto";
 import "auth.proto";
 
-package jetcd;
+package etcdserverpb;
 
 option java_multiple_files = true;
 option java_package = "com.coreos.jetcd.api";


### PR DESCRIPTION
In etcd server, the service package is "etcdserverpb".

if we use jetcd in our proto file, we can't access the servies like KV service.

So we have to rollback to "etcdserverpb".