### PR TITLE
pom.xml: upgrade grpc and protobuf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,11 +27,11 @@
         <protobuf-maven-plugin.version>0.5.0</protobuf-maven-plugin.version>
 
         <!-- dependencies -->
-        <grpc.version>0.15.0</grpc.version>
+        <grpc.version>1.0.0</grpc.version>
         <slf4j.version>1.7.21</slf4j.version>
 
         <!-- should be in sync with protobuf grpc dependencies -->
-        <protobuf.version>3.0.0-beta-3</protobuf.version>
+        <protobuf.version>3.0.0</protobuf.version>
 
         <!-- test dependencies -->
         <testng.version>6.9.10</testng.version>


### PR DESCRIPTION
The stable versions of grpc and protobuf are released now.
* grpc: 1.0.0
* protobuf: 3.0.0