### PR TITLE
pom.xml: Enabling checkstyle at compile time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,45 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>2.17</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>6.15</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                        <version>19.0</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <configLocation>google_checks.xml</configLocation>
+                    <encoding>UTF-8</encoding>
+                    <consoleOutput>true</consoleOutput>
+                    <failsOnError>true</failsOnError>
+                    <!-- enabling this after refactoring of making coding style consistent -->
+                    <!-- <failOnViolation>true</failOnViolation> -->
+                    <!-- <violationSeverity>warning</violationSeverity> -->
+                    <format>xml</format>
+                    <format>html</format>
+                    <outputFile>${project.build.directory}/test/checkstyle-errors.xml</outputFile>
+                    <linkXRef>false</linkXRef>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This PR enables checkstyle at compile time with maven-checkstyle-plugin. In this PR, it uses google_checks.xml as coding style, but it can be changed based on discussion here.