### PR TITLE
Front page instructions on how to run the tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ target/
 logs/
 *.releaseBackup
 *.versionsBackup
+
+# Created by './scripts/run_etcd.sh'
+/external/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,59 @@ kvClient.delete(key).get()
 
 For full etcd v3 API, plesase refer to [API_Reference](https://github.com/coreos/etcd/blob/master/Documentation/dev-guide/api_reference_v3.md).
 
+## Running tests
+
+The project is to be tested against a three node `etcd` setup, launched by the [scripts/run_etcd.sh](scripts/run_etcd.sh) shell script:
+
+```
+./scripts/run_etcd.sh
+```
+
+It should work on either macOS or Linux.
+
+Note: Make sure you don't have a default `etcd` running on your system! The script uses the default port `2379` for the first node, which fails to launch if that port is already taken.
+
+```
+mvn test
+...
+
+-------------------------------------------------------
+ T E S T S
+-------------------------------------------------------
+Running TestSuite
+Feb 23, 2017 6:40:18 PM io.grpc.internal.ManagedChannelImpl <init>
+INFO: [ManagedChannelImpl@48a242ce] Created with target etcd
+Feb 23, 2017 6:40:18 PM io.grpc.internal.ManagedChannelImpl <init>
+INFO: [ManagedChannelImpl@20d3d15a] Created with target etcd
+Feb 23, 2017 6:40:18 PM io.grpc.internal.ManagedChannelImpl <init>
+INFO: [ManagedChannelImpl@548a102f] Created with target etcd
+Feb 23, 2017 6:40:18 PM io.grpc.internal.ManagedChannelImpl <init>
+INFO: [ManagedChannelImpl@17c386de] Created with target etcd
+Feb 23, 2017 6:40:19 PM io.grpc.internal.ManagedChannelImpl <init>
+INFO: [ManagedChannelImpl@25d250c6] Created with target etcd
+Feb 23, 2017 6:40:27 PM io.grpc.internal.ManagedChannelImpl <init>
+INFO: [ManagedChannelImpl@3eb7fc54] Created with target etcd
+Feb 23, 2017 6:40:27 PM io.grpc.internal.ManagedChannelImpl <init>
+INFO: [ManagedChannelImpl@6ef888f6] Created with target etcd
+Feb 23, 2017 6:40:33 PM io.grpc.internal.ManagedChannelImpl <init>
+INFO: [ManagedChannelImpl@49b0b76] Created with target etcd
+Feb 23, 2017 6:40:33 PM io.grpc.internal.ManagedChannelImpl <init>
+INFO: [ManagedChannelImpl@6f96c77] Created with target etcd
+Tests run: 37, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 16.797 sec - in TestSuite
+
+Results :
+
+Tests run: 37, Failures: 0, Errors: 0, Skipped: 0
+
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time: 39.229 s
+[INFO] Finished at: 2017-02-23T18:40:34+02:00
+[INFO] Final Memory: 37M/587M
+[INFO] ------------------------------------------------------------------------
+```
+
 ## Contact
 
 * Mailing list: [etcd-dev](https://groups.google.com/forum/?hl=en#!forum/etcd-dev)


### PR DESCRIPTION
Crucial information on how newcomers can check that the code base is healthy on their system.

I took a big bunch of console output in. Personally I find it good to see what I'm expected to see when tests run, especially when a project is in a young stage like this one. This block can of course be trimmed down.

- Wouldn't it be nicer to run the etcd cluster in Docker, instead of natively via shell script?
- That might also make things Windows compatible (now macOS and Linux are supported by the shell script)

I personally find Docker more ... trustworthy than a shell script that loads quite a lot off the Internet.

- Is it necessary to run the first cluster node off port `2379`? If it were, say `12379`, chances of conflicting with an existing installation would be virtually zero.

Can make Issues on the above entries, but writing these instructions brought them up, so wanted to ask first.