### PR TITLE
del user and role after disable auth

### DIFF
--- a/src/test/java/com/coreos/jetcd/EtcdAuthClientTest.java
+++ b/src/test/java/com/coreos/jetcd/EtcdAuthClientTest.java
@@ -162,7 +162,7 @@ public class EtcdAuthClientTest {
   public void delUser() {
     Throwable err = null;
     try {
-      this.authEtcdClient.getAuthClient().userDelete(userName).get();
+      this.etcdClient.getAuthClient().userDelete(userName).get();
     } catch (Exception e) {
       err = e;
     }
@@ -176,7 +176,7 @@ public class EtcdAuthClientTest {
   public void delRole() {
     Throwable err = null;
     try {
-      this.authEtcdClient.getAuthClient().roleDelete(roleName).get();
+      this.etcdClient.getAuthClient().roleDelete(roleName).get();
     } catch (Exception e) {
       err = e;
     }


### PR DESCRIPTION
After disable auth,use the non-auth client connection to delete test user and role.