### PR TITLE
client: replace ByteString with ByteSequence

### DIFF
--- a/src/main/java/com/coreos/jetcd/Auth.java
+++ b/src/main/java/com/coreos/jetcd/Auth.java
@@ -16,7 +16,7 @@ import com.coreos.jetcd.api.AuthUserGrantRoleResponse;
 import com.coreos.jetcd.api.AuthUserListResponse;
 import com.coreos.jetcd.api.AuthUserRevokeRoleResponse;
 import com.coreos.jetcd.api.Permission;
-import com.google.protobuf.ByteString;
+import com.coreos.jetcd.data.ByteSequence;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -36,14 +36,14 @@ public interface Auth {
   // User Manage
   // ***************
 
-  CompletableFuture<AuthUserAddResponse> userAdd(ByteString name, ByteString password);
+  CompletableFuture<AuthUserAddResponse> userAdd(ByteSequence name, ByteSequence password);
 
-  CompletableFuture<AuthUserDeleteResponse> userDelete(ByteString name);
+  CompletableFuture<AuthUserDeleteResponse> userDelete(ByteSequence name);
 
-  CompletableFuture<AuthUserChangePasswordResponse> userChangePassword(ByteString name,
-      ByteString password);
+  CompletableFuture<AuthUserChangePasswordResponse> userChangePassword(ByteSequence name,
+      ByteSequence password);
 
-  CompletableFuture<AuthUserGetResponse> userGet(ByteString name);
+  CompletableFuture<AuthUserGetResponse> userGet(ByteSequence name);
 
   CompletableFuture<AuthUserListResponse> userList();
 
@@ -51,28 +51,29 @@ public interface Auth {
   // User Role Manage
   // ***************
 
-  CompletableFuture<AuthUserGrantRoleResponse> userGrantRole(ByteString name, ByteString role);
+  CompletableFuture<AuthUserGrantRoleResponse> userGrantRole(ByteSequence name, ByteSequence role);
 
-  CompletableFuture<AuthUserRevokeRoleResponse> userRevokeRole(ByteString name, ByteString role);
+  CompletableFuture<AuthUserRevokeRoleResponse> userRevokeRole(ByteSequence name,
+      ByteSequence role);
 
   // ***************
   // Role Manage
   // ***************
 
-  CompletableFuture<AuthRoleAddResponse> roleAdd(ByteString name);
+  CompletableFuture<AuthRoleAddResponse> roleAdd(ByteSequence name);
 
-  CompletableFuture<AuthRoleGrantPermissionResponse> roleGrantPermission(ByteString role,
-      ByteString key,
-      ByteString rangeEnd, Permission.Type permType);
+  CompletableFuture<AuthRoleGrantPermissionResponse> roleGrantPermission(ByteSequence role,
+      ByteSequence key,
+      ByteSequence rangeEnd, Permission.Type permType);
 
-  CompletableFuture<AuthRoleGetResponse> roleGet(ByteString role);
+  CompletableFuture<AuthRoleGetResponse> roleGet(ByteSequence role);
 
   CompletableFuture<AuthRoleListResponse> roleList();
 
-  CompletableFuture<AuthRoleRevokePermissionResponse> roleRevokePermission(ByteString role,
-      ByteString key,
-      ByteString rangeEnd);
+  CompletableFuture<AuthRoleRevokePermissionResponse> roleRevokePermission(ByteSequence role,
+      ByteSequence key,
+      ByteSequence rangeEnd);
 
-  CompletableFuture<AuthRoleDeleteResponse> roleDelete(ByteString role);
+  CompletableFuture<AuthRoleDeleteResponse> roleDelete(ByteSequence role);
 
 }

--- a/src/main/java/com/coreos/jetcd/AuthImpl.java
+++ b/src/main/java/com/coreos/jetcd/AuthImpl.java
@@ -1,5 +1,7 @@
 package com.coreos.jetcd;
 
+import static com.coreos.jetcd.Util.byteStringFromByteSequence;
+
 import com.coreos.jetcd.api.AuthDisableRequest;
 import com.coreos.jetcd.api.AuthDisableResponse;
 import com.coreos.jetcd.api.AuthEnableRequest;
@@ -32,7 +34,7 @@ import com.coreos.jetcd.api.AuthUserListResponse;
 import com.coreos.jetcd.api.AuthUserRevokeRoleRequest;
 import com.coreos.jetcd.api.AuthUserRevokeRoleResponse;
 import com.coreos.jetcd.api.Permission;
-import com.google.protobuf.ByteString;
+import com.coreos.jetcd.data.ByteSequence;
 import io.grpc.ManagedChannel;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -70,35 +72,35 @@ public class AuthImpl implements Auth {
   // ***************
 
   @Override
-  public CompletableFuture<AuthUserAddResponse> userAdd(ByteString name, ByteString password) {
+  public CompletableFuture<AuthUserAddResponse> userAdd(ByteSequence name, ByteSequence password) {
     AuthUserAddRequest addRequest = AuthUserAddRequest.newBuilder()
-        .setNameBytes(name)
-        .setPasswordBytes(password)
+        .setNameBytes(byteStringFromByteSequence(name))
+        .setPasswordBytes(byteStringFromByteSequence(password))
         .build();
     return FutureConverter.toCompletableFuture(this.stub.userAdd(addRequest));
   }
 
   @Override
-  public CompletableFuture<AuthUserDeleteResponse> userDelete(ByteString name) {
+  public CompletableFuture<AuthUserDeleteResponse> userDelete(ByteSequence name) {
     AuthUserDeleteRequest deleteRequest = AuthUserDeleteRequest.newBuilder()
-        .setNameBytes(name).build();
+        .setNameBytes(byteStringFromByteSequence(name)).build();
     return FutureConverter.toCompletableFuture(this.stub.userDelete(deleteRequest));
   }
 
   @Override
-  public CompletableFuture<AuthUserChangePasswordResponse> userChangePassword(ByteString name,
-      ByteString password) {
+  public CompletableFuture<AuthUserChangePasswordResponse> userChangePassword(ByteSequence name,
+      ByteSequence password) {
     AuthUserChangePasswordRequest changePasswordRequest = AuthUserChangePasswordRequest.newBuilder()
-        .setNameBytes(name)
-        .setPasswordBytes(password)
+        .setNameBytes(byteStringFromByteSequence(name))
+        .setPasswordBytes(byteStringFromByteSequence(password))
         .build();
     return FutureConverter.toCompletableFuture(this.stub.userChangePassword(changePasswordRequest));
   }
 
   @Override
-  public CompletableFuture<AuthUserGetResponse> userGet(ByteString name) {
+  public CompletableFuture<AuthUserGetResponse> userGet(ByteSequence name) {
     AuthUserGetRequest userGetRequest = AuthUserGetRequest.newBuilder()
-        .setNameBytes(name)
+        .setNameBytes(byteStringFromByteSequence(name))
         .build();
 
     return FutureConverter.toCompletableFuture(this.stub.userGet(userGetRequest));
@@ -115,21 +117,21 @@ public class AuthImpl implements Auth {
   // ***************
 
   @Override
-  public CompletableFuture<AuthUserGrantRoleResponse> userGrantRole(ByteString name,
-      ByteString role) {
+  public CompletableFuture<AuthUserGrantRoleResponse> userGrantRole(ByteSequence name,
+      ByteSequence role) {
     AuthUserGrantRoleRequest userGrantRoleRequest = AuthUserGrantRoleRequest.newBuilder()
-        .setUserBytes(name)
-        .setRoleBytes(role)
+        .setUserBytes(byteStringFromByteSequence(name))
+        .setRoleBytes(byteStringFromByteSequence(role))
         .build();
     return FutureConverter.toCompletableFuture(this.stub.userGrantRole(userGrantRoleRequest));
   }
 
   @Override
-  public CompletableFuture<AuthUserRevokeRoleResponse> userRevokeRole(ByteString name,
-      ByteString role) {
+  public CompletableFuture<AuthUserRevokeRoleResponse> userRevokeRole(ByteSequence name,
+      ByteSequence role) {
     AuthUserRevokeRoleRequest userRevokeRoleRequest = AuthUserRevokeRoleRequest.newBuilder()
-        .setNameBytes(name)
-        .setRoleBytes(role)
+        .setNameBytes(byteStringFromByteSequence(name))
+        .setRoleBytes(byteStringFromByteSequence(role))
         .build();
     return FutureConverter.toCompletableFuture(this.stub.userRevokeRole(userRevokeRoleRequest));
   }
@@ -139,24 +141,24 @@ public class AuthImpl implements Auth {
   // ***************
 
   @Override
-  public CompletableFuture<AuthRoleAddResponse> roleAdd(ByteString name) {
+  public CompletableFuture<AuthRoleAddResponse> roleAdd(ByteSequence name) {
     AuthRoleAddRequest roleAddRequest = AuthRoleAddRequest.newBuilder()
-        .setNameBytes(name)
+        .setNameBytes(byteStringFromByteSequence(name))
         .build();
     return FutureConverter.toCompletableFuture(this.stub.roleAdd(roleAddRequest));
   }
 
   @Override
-  public CompletableFuture<AuthRoleGrantPermissionResponse> roleGrantPermission(ByteString role,
-      ByteString key, ByteString rangeEnd, Permission.Type permType) {
+  public CompletableFuture<AuthRoleGrantPermissionResponse> roleGrantPermission(ByteSequence role,
+      ByteSequence key, ByteSequence rangeEnd, Permission.Type permType) {
     Permission perm = Permission.newBuilder()
-        .setKey(key)
-        .setRangeEnd(rangeEnd)
+        .setKey(byteStringFromByteSequence(key))
+        .setRangeEnd(byteStringFromByteSequence(rangeEnd))
         .setPermType(permType)
         .build();
     AuthRoleGrantPermissionRequest roleGrantPermissionRequest = AuthRoleGrantPermissionRequest
         .newBuilder()
-        .setNameBytes(role)
+        .setNameBytes(byteStringFromByteSequence(role))
         .setPerm(perm)
         .build();
 
@@ -165,9 +167,9 @@ public class AuthImpl implements Auth {
   }
 
   @Override
-  public CompletableFuture<AuthRoleGetResponse> roleGet(ByteString role) {
+  public CompletableFuture<AuthRoleGetResponse> roleGet(ByteSequence role) {
     AuthRoleGetRequest roleGetRequest = AuthRoleGetRequest.newBuilder()
-        .setRoleBytes(role)
+        .setRoleBytes(byteStringFromByteSequence(role))
         .build();
     return FutureConverter.toCompletableFuture(this.stub.roleGet(roleGetRequest));
   }
@@ -179,24 +181,24 @@ public class AuthImpl implements Auth {
   }
 
   @Override
-  public CompletableFuture<AuthRoleRevokePermissionResponse> roleRevokePermission(ByteString role,
-      ByteString key, ByteString rangeEnd) {
+  public CompletableFuture<AuthRoleRevokePermissionResponse> roleRevokePermission(ByteSequence role,
+      ByteSequence key, ByteSequence rangeEnd) {
 
     AuthRoleRevokePermissionRequest roleRevokePermissionRequest = AuthRoleRevokePermissionRequest
         .newBuilder()
-        .setRoleBytes(role)
-        .setKeyBytes(key)
-        .setRangeEndBytes(rangeEnd)
+        .setRoleBytes(byteStringFromByteSequence(role))
+        .setKeyBytes(byteStringFromByteSequence(key))
+        .setRangeEndBytes(byteStringFromByteSequence(rangeEnd))
         .build();
     return FutureConverter
         .toCompletableFuture(this.stub.roleRevokePermission(roleRevokePermissionRequest));
   }
 
   @Override
-  public CompletableFuture<AuthRoleDeleteResponse> roleDelete(ByteString role) {
+  public CompletableFuture<AuthRoleDeleteResponse> roleDelete(ByteSequence role) {
 
     AuthRoleDeleteRequest roleDeleteRequest = AuthRoleDeleteRequest.newBuilder()
-        .setRoleBytes(role)
+        .setRoleBytes(byteStringFromByteSequence(role))
         .build();
     return FutureConverter.toCompletableFuture(this.stub.roleDelete(roleDeleteRequest));
   }

--- a/src/main/java/com/coreos/jetcd/Client.java
+++ b/src/main/java/com/coreos/jetcd/Client.java
@@ -1,6 +1,7 @@
 package com.coreos.jetcd;
 
 import static com.coreos.jetcd.ClientUtil.defaultChannelBuilder;
+import static com.coreos.jetcd.Util.byteStringFromByteSequence;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -72,8 +73,8 @@ public class Client {
       checkNotNull(clientBuilder.endpoints(), "endpoints can't be null");
       this.nameResolverFactory = ClientUtil.simpleNameResolveFactory(clientBuilder.endpoints());
     }
-    this.user = clientBuilder.getName();
-    this.pass = clientBuilder.getPassword();
+    this.user = byteStringFromByteSequence(clientBuilder.getName());
+    this.pass = byteStringFromByteSequence(clientBuilder.getPassword());
 
     Pair<ManagedChannel, Optional<String>> channelToken = this
         .toChannelAndToken(

--- a/src/main/java/com/coreos/jetcd/Client.java
+++ b/src/main/java/com/coreos/jetcd/Client.java
@@ -73,8 +73,14 @@ public class Client {
       checkNotNull(clientBuilder.endpoints(), "endpoints can't be null");
       this.nameResolverFactory = ClientUtil.simpleNameResolveFactory(clientBuilder.endpoints());
     }
-    this.user = byteStringFromByteSequence(clientBuilder.getName());
-    this.pass = byteStringFromByteSequence(clientBuilder.getPassword());
+
+    if (clientBuilder.getName() != null && clientBuilder.getPassword() != null) {
+      this.user = byteStringFromByteSequence(clientBuilder.getName());
+      this.pass = byteStringFromByteSequence(clientBuilder.getPassword());
+    } else {
+      this.user = null;
+      this.pass = null;
+    }
 
     Pair<ManagedChannel, Optional<String>> channelToken = this
         .toChannelAndToken(

--- a/src/main/java/com/coreos/jetcd/ClientBuilder.java
+++ b/src/main/java/com/coreos/jetcd/ClientBuilder.java
@@ -4,11 +4,11 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
+import com.coreos.jetcd.data.ByteSequence;
 import com.coreos.jetcd.exception.AuthFailedException;
 import com.coreos.jetcd.exception.ConnectException;
 import com.coreos.jetcd.resolver.AbstractEtcdNameResolverFactory;
 import com.google.common.collect.Lists;
-import com.google.protobuf.ByteString;
 import java.util.List;
 
 /**
@@ -17,8 +17,8 @@ import java.util.List;
 public class ClientBuilder {
 
   private List<String> endpoints = Lists.newArrayList();
-  private ByteString name;
-  private ByteString password;
+  private ByteSequence name;
+  private ByteSequence password;
   private AbstractEtcdNameResolverFactory nameResolverFactory;
 
   private ClientBuilder() {
@@ -60,7 +60,7 @@ public class ClientBuilder {
     return this;
   }
 
-  public ByteString getName() {
+  public ByteSequence getName() {
     return name;
   }
 
@@ -71,13 +71,13 @@ public class ClientBuilder {
    * @return this builder
    * @throws NullPointerException if name is null
    */
-  public ClientBuilder setName(ByteString name) {
+  public ClientBuilder setName(ByteSequence name) {
     checkNotNull(name, "name can't be null");
     this.name = name;
     return this;
   }
 
-  public ByteString getPassword() {
+  public ByteSequence getPassword() {
     return password;
   }
 
@@ -88,7 +88,7 @@ public class ClientBuilder {
    * @return this builder
    * @throws NullPointerException if password is null
    */
-  public ClientBuilder setPassword(ByteString password) {
+  public ClientBuilder setPassword(ByteSequence password) {
     checkNotNull(password, "password can't be null");
     this.password = password;
     return this;

--- a/src/main/java/com/coreos/jetcd/Constants.java
+++ b/src/main/java/com/coreos/jetcd/Constants.java
@@ -1,6 +1,6 @@
 package com.coreos.jetcd;
 
-import com.google.protobuf.ByteString;
+import com.coreos.jetcd.data.ByteSequence;
 
 /**
  * Constants of Etcd.
@@ -8,5 +8,5 @@ import com.google.protobuf.ByteString;
 public class Constants {
 
   public static final String TOKEN = "token";
-  public static final ByteString NULL_KEY = ByteString.copyFrom(new byte[]{'\0'});
+  public static final ByteSequence NULL_KEY = ByteSequence.fromBytes(new byte[]{'\0'});
 }

--- a/src/main/java/com/coreos/jetcd/KV.java
+++ b/src/main/java/com/coreos/jetcd/KV.java
@@ -5,13 +5,13 @@ import com.coreos.jetcd.api.DeleteRangeResponse;
 import com.coreos.jetcd.api.PutResponse;
 import com.coreos.jetcd.api.RangeResponse;
 import com.coreos.jetcd.api.TxnResponse;
+import com.coreos.jetcd.data.ByteSequence;
 import com.coreos.jetcd.op.Txn;
 import com.coreos.jetcd.options.CompactOption;
 import com.coreos.jetcd.options.DeleteOption;
 import com.coreos.jetcd.options.GetOption;
 import com.coreos.jetcd.options.PutOption;
 import com.google.common.annotations.Beta;
-import com.google.protobuf.ByteString;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -24,25 +24,25 @@ public interface KV {
   // Op.PUT
   // ***************
 
-  CompletableFuture<PutResponse> put(ByteString key, ByteString value);
+  CompletableFuture<PutResponse> put(ByteSequence key, ByteSequence value);
 
-  CompletableFuture<PutResponse> put(ByteString key, ByteString value, PutOption option);
+  CompletableFuture<PutResponse> put(ByteSequence key, ByteSequence value, PutOption option);
 
   // ***************
   // Op.GET
   // ***************
 
-  CompletableFuture<RangeResponse> get(ByteString key);
+  CompletableFuture<RangeResponse> get(ByteSequence key);
 
-  CompletableFuture<RangeResponse> get(ByteString key, GetOption option);
+  CompletableFuture<RangeResponse> get(ByteSequence key, GetOption option);
 
   // ***************
   // Op.DELETE
   // ***************
 
-  CompletableFuture<DeleteRangeResponse> delete(ByteString key);
+  CompletableFuture<DeleteRangeResponse> delete(ByteSequence key);
 
-  CompletableFuture<DeleteRangeResponse> delete(ByteString key, DeleteOption option);
+  CompletableFuture<DeleteRangeResponse> delete(ByteSequence key, DeleteOption option);
 
   // ***************
   // Op.COMPACT

--- a/src/main/java/com/coreos/jetcd/op/Cmp.java
+++ b/src/main/java/com/coreos/jetcd/op/Cmp.java
@@ -1,6 +1,7 @@
 package com.coreos.jetcd.op;
 
 import com.coreos.jetcd.api.Compare;
+import com.coreos.jetcd.data.ByteSequence;
 import com.google.protobuf.ByteString;
 
 /**
@@ -16,8 +17,8 @@ public class Cmp {
   private final Op op;
   private final CmpTarget<?> target;
 
-  public Cmp(ByteString key, Op compareOp, CmpTarget<?> target) {
-    this.key = key;
+  public Cmp(ByteSequence key, Op compareOp, CmpTarget<?> target) {
+    this.key = ByteString.copyFrom(key.getBytes());
     this.op = compareOp;
     this.target = target;
   }

--- a/src/main/java/com/coreos/jetcd/op/CmpTarget.java
+++ b/src/main/java/com/coreos/jetcd/op/CmpTarget.java
@@ -1,6 +1,7 @@
 package com.coreos.jetcd.op;
 
 import com.coreos.jetcd.api.Compare;
+import com.coreos.jetcd.data.ByteSequence;
 import com.google.protobuf.ByteString;
 
 /**
@@ -44,8 +45,8 @@ public abstract class CmpTarget<T> {
    * @param value the value to compare
    * @return the value compare target
    */
-  public static ValueCmpTarget value(ByteString value) {
-    return new ValueCmpTarget(value);
+  public static ValueCmpTarget value(ByteSequence value) {
+    return new ValueCmpTarget(ByteString.copyFrom(value.getBytes()));
   }
 
   private final Compare.CompareTarget target;

--- a/src/main/java/com/coreos/jetcd/op/Op.java
+++ b/src/main/java/com/coreos/jetcd/op/Op.java
@@ -4,6 +4,7 @@ import com.coreos.jetcd.api.DeleteRangeRequest;
 import com.coreos.jetcd.api.PutRequest;
 import com.coreos.jetcd.api.RangeRequest;
 import com.coreos.jetcd.api.RequestOp;
+import com.coreos.jetcd.data.ByteSequence;
 import com.coreos.jetcd.options.DeleteOption;
 import com.coreos.jetcd.options.GetOption;
 import com.coreos.jetcd.options.PutOption;
@@ -31,16 +32,17 @@ public abstract class Op {
 
   abstract RequestOp toRequestOp();
 
-  public static PutOp put(ByteString key, ByteString value, PutOption option) {
-    return new PutOp(key, value, option);
+  public static PutOp put(ByteSequence key, ByteSequence value, PutOption option) {
+    return new PutOp(ByteString.copyFrom(key.getBytes()), ByteString.copyFrom(value.getBytes()),
+        option);
   }
 
-  public static GetOp get(ByteString key, GetOption option) {
-    return new GetOp(key, option);
+  public static GetOp get(ByteSequence key, GetOption option) {
+    return new GetOp(ByteString.copyFrom(key.getBytes()), option);
   }
 
-  public static DeleteOp delete(ByteString key, DeleteOption option) {
-    return new DeleteOp(key, option);
+  public static DeleteOp delete(ByteSequence key, DeleteOption option) {
+    return new DeleteOp(ByteString.copyFrom(key.getBytes()), option);
   }
 
   public static final class PutOp extends Op {
@@ -87,7 +89,7 @@ public abstract class Op {
           .setSortTarget(this.option.getSortField());
 
       if (this.option.getEndKey().isPresent()) {
-        range.setRangeEnd(this.option.getEndKey().get());
+        range.setRangeEnd(ByteString.copyFrom(this.option.getEndKey().get().getBytes()));
       }
 
       return RequestOp.newBuilder().setRequestRange(range).build();
@@ -109,7 +111,7 @@ public abstract class Op {
           .setPrevKv(this.option.isPrevKV());
 
       if (this.option.getEndKey().isPresent()) {
-        delete.setRangeEnd(this.option.getEndKey().get());
+        delete.setRangeEnd(ByteString.copyFrom(this.option.getEndKey().get().getBytes()));
       }
 
       return RequestOp.newBuilder().setRequestDeleteRange(delete).build();

--- a/src/main/java/com/coreos/jetcd/options/DeleteOption.java
+++ b/src/main/java/com/coreos/jetcd/options/DeleteOption.java
@@ -3,8 +3,9 @@ package com.coreos.jetcd.options;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.coreos.jetcd.KV;
+import com.coreos.jetcd.data.ByteSequence;
 import com.google.common.base.Optional;
-import com.google.protobuf.ByteString;
+
 
 public final class DeleteOption {
 
@@ -16,7 +17,7 @@ public final class DeleteOption {
 
   public static class Builder {
 
-    private Optional<ByteString> endKey = Optional.absent();
+    private Optional<ByteSequence> endKey = Optional.absent();
     private boolean prevKV = false;
 
     private Builder() {
@@ -37,7 +38,7 @@ public final class DeleteOption {
      * @param endKey end key
      * @return builder
      */
-    public Builder withRange(ByteString endKey) {
+    public Builder withRange(ByteSequence endKey) {
       this.endKey = Optional.fromNullable(endKey);
       return this;
     }
@@ -46,15 +47,15 @@ public final class DeleteOption {
      * Enables 'Delete' requests to delete all the keys with matching prefix.
      *
      * <p>You should pass the key that is passed into
-     * {@link KV#delete(ByteString) KV.delete} method
+     * {@link KV#delete(ByteSequence) KV.delete} method
      * into this method as the given key.
      *
      * @param prefix the common prefix of all the keys that you want to delete
      * @return builder
      */
-    public Builder withPrefix(ByteString prefix) {
+    public Builder withPrefix(ByteSequence prefix) {
       checkNotNull(prefix, "prefix should not be null");
-      ByteString prefixEnd = OptionsUtil.prefixEndOf(prefix);
+      ByteSequence prefixEnd = OptionsUtil.prefixEndOf(prefix);
       this.withRange(prefixEnd);
       return this;
     }
@@ -76,15 +77,15 @@ public final class DeleteOption {
 
   }
 
-  private final Optional<ByteString> endKey;
+  private final Optional<ByteSequence> endKey;
   private final boolean prevKV;
 
-  private DeleteOption(Optional<ByteString> endKey, boolean prevKV) {
+  private DeleteOption(Optional<ByteSequence> endKey, boolean prevKV) {
     this.endKey = endKey;
     this.prevKV = prevKV;
   }
 
-  public Optional<ByteString> getEndKey() {
+  public Optional<ByteSequence> getEndKey() {
     return endKey;
   }
 

--- a/src/main/java/com/coreos/jetcd/options/GetOption.java
+++ b/src/main/java/com/coreos/jetcd/options/GetOption.java
@@ -4,7 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.coreos.jetcd.KV;
 import com.coreos.jetcd.api.RangeRequest;
-import com.google.protobuf.ByteString;
+import com.coreos.jetcd.data.ByteSequence;
 import java.util.Optional;
 
 /**
@@ -32,7 +32,7 @@ public final class GetOption {
     private boolean serializable = false;
     private boolean keysOnly = false;
     private boolean countOnly = false;
-    private Optional<ByteString> endKey = Optional.empty();
+    private Optional<ByteSequence> endKey = Optional.empty();
 
     private Builder() {
     }
@@ -137,7 +137,7 @@ public final class GetOption {
      * @param endKey end key
      * @return builder
      */
-    public Builder withRange(ByteString endKey) {
+    public Builder withRange(ByteSequence endKey) {
       this.endKey = Optional.ofNullable(endKey);
       return this;
     }
@@ -146,15 +146,15 @@ public final class GetOption {
      * Enables 'Get' requests to obtain all the keys with matching prefix.
      *
      * <p>You should pass the key that is passed into
-     * {@link KV#get(ByteString) KV.get} method
+     * {@link KV#get(ByteSequence) KV.get} method
      * into this method as the given key.
      *
      * @param prefix the common prefix of all the keys that you want to get
      * @return builder
      */
-    public Builder withPrefix(ByteString prefix) {
+    public Builder withPrefix(ByteSequence prefix) {
       checkNotNull(prefix, "prefix should not be null");
-      ByteString prefixEnd = OptionsUtil.prefixEndOf(prefix);
+      ByteSequence prefixEnd = OptionsUtil.prefixEndOf(prefix);
       this.withRange(prefixEnd);
       return this;
     }
@@ -166,7 +166,7 @@ public final class GetOption {
 
   }
 
-  private final Optional<ByteString> endKey;
+  private final Optional<ByteSequence> endKey;
   private final long limit;
   private final long revision;
   private final RangeRequest.SortOrder sortOrder;
@@ -175,7 +175,7 @@ public final class GetOption {
   private final boolean keysOnly;
   private final boolean countOnly;
 
-  private GetOption(Optional<ByteString> endKey, long limit, long revision,
+  private GetOption(Optional<ByteSequence> endKey, long limit, long revision,
       RangeRequest.SortOrder sortOrder,
       RangeRequest.SortTarget sortTarget, boolean serializable, boolean keysOnly,
       boolean countOnly) {
@@ -198,7 +198,7 @@ public final class GetOption {
     return this.limit;
   }
 
-  public Optional<ByteString> getEndKey() {
+  public Optional<ByteSequence> getEndKey() {
     return this.endKey;
   }
 

--- a/src/main/java/com/coreos/jetcd/options/OptionsUtil.java
+++ b/src/main/java/com/coreos/jetcd/options/OptionsUtil.java
@@ -1,5 +1,6 @@
 package com.coreos.jetcd.options;
 
+import com.coreos.jetcd.data.ByteSequence;
 import com.google.protobuf.ByteString;
 import java.util.Arrays;
 
@@ -18,15 +19,15 @@ public class OptionsUtil {
    * @param prefix the given prefix
    * @return the range end of the given prefix
    */
-  static final ByteString prefixEndOf(ByteString prefix) {
-    byte[] endKey = prefix.toByteArray().clone();
+  static final ByteSequence prefixEndOf(ByteSequence prefix) {
+    byte[] endKey = prefix.getBytes().clone();
     for (int i = endKey.length - 1; i >= 0; i--) {
       if (endKey[i] < 0xff) {
         endKey[i] = (byte) (endKey[i] + 1);
-        return ByteString.copyFrom(Arrays.copyOf(endKey, i + 1));
+        return ByteSequence.fromBytes(Arrays.copyOf(endKey, i + 1));
       }
     }
 
-    return ByteString.copyFrom(NO_PREFIX_END);
+    return ByteSequence.fromBytes(NO_PREFIX_END);
   }
 }

--- a/src/test/java/com/coreos/jetcd/AuthClientTest.java
+++ b/src/test/java/com/coreos/jetcd/AuthClientTest.java
@@ -3,11 +3,10 @@ package com.coreos.jetcd;
 import com.coreos.jetcd.api.AuthRoleGetResponse;
 import com.coreos.jetcd.api.Permission;
 import com.coreos.jetcd.api.RangeResponse;
+import com.coreos.jetcd.data.ByteSequence;
 import com.coreos.jetcd.exception.AuthFailedException;
 import com.coreos.jetcd.exception.ConnectException;
-import com.google.protobuf.ByteString;
 import io.grpc.StatusRuntimeException;
-import java.nio.charset.Charset;
 import java.util.concurrent.ExecutionException;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -21,16 +20,16 @@ public class AuthClientTest {
   private Auth authClient;
   private KV kvClient;
 
-  private ByteString roleName = ByteString.copyFromUtf8("root");
+  private ByteSequence roleName = ByteSequence.fromString("root");
 
-  private ByteString keyRangeBegin = ByteString.copyFromUtf8("foo");
-  private ByteString keyRangeEnd = ByteString.copyFromUtf8("zoo");
+  private ByteSequence keyRangeBegin = ByteSequence.fromString("foo");
+  private ByteSequence keyRangeEnd = ByteSequence.fromString("zoo");
 
-  private ByteString testKey = ByteString.copyFromUtf8("foo1");
-  private ByteString testName = ByteString.copyFromUtf8("bar");
+  private ByteSequence testKey = ByteSequence.fromString("foo1");
+  private ByteSequence testName = ByteSequence.fromString("bar1");
 
-  private ByteString userName = ByteString.copyFrom("root", Charset.defaultCharset());
-  private ByteString password = ByteString.copyFrom("123", Charset.defaultCharset());
+  private ByteSequence userName = ByteSequence.fromString("root");
+  private ByteSequence password = ByteSequence.fromString("123");
 
   private Assertion test;
 
@@ -76,7 +75,8 @@ public class AuthClientTest {
   /**
    * grant user role
    */
-  @Test(dependsOnMethods = {"testUserAdd", "testRoleGrantPermission"}, groups = "user", priority = 1)
+  @Test(dependsOnMethods = {"testUserAdd",
+      "testRoleGrantPermission"}, groups = "user", priority = 1)
   public void testUserGrantRole() throws ExecutionException, InterruptedException {
     this.authClient.userGrantRole(userName, roleName).get();
   }
@@ -108,8 +108,8 @@ public class AuthClientTest {
     try {
       this.secureClient.getKVClient().put(testKey, testName).get();
       RangeResponse rangeResponse = this.secureClient.getKVClient().get(testKey).get();
-      this.test.assertTrue(
-          rangeResponse.getCount() != 0 && rangeResponse.getKvs(0).getValue().equals(testName));
+      this.test.assertTrue(rangeResponse.getCount() != 0);
+      this.test.assertEquals(rangeResponse.getKvs(0).getValue().toByteArray(), testName.getBytes());
     } catch (StatusRuntimeException sre) {
       err = sre;
     }

--- a/src/test/java/com/coreos/jetcd/LeaseTest.java
+++ b/src/test/java/com/coreos/jetcd/LeaseTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.coreos.jetcd.Lease.LeaseHandler;
 import com.coreos.jetcd.api.LeaseKeepAliveResponse;
 import com.coreos.jetcd.api.PutResponse;
+import com.coreos.jetcd.data.ByteSequence;
 import com.coreos.jetcd.options.PutOption;
 import com.google.protobuf.ByteString;
 import java.util.concurrent.ExecutionException;
@@ -23,8 +24,8 @@ public class LeaseTest {
   private Assertion test;
 
 
-  private static final ByteString KEY = ByteString.copyFromUtf8("foo");
-  private static final ByteString VALUE = ByteString.copyFromUtf8("bar");
+  private static final ByteSequence KEY = ByteSequence.fromString("foo");
+  private static final ByteSequence VALUE = ByteSequence.fromString("bar");
 
   @BeforeTest
   public void setUp() throws Exception {

--- a/src/test/java/com/coreos/jetcd/WatchTest.java
+++ b/src/test/java/com/coreos/jetcd/WatchTest.java
@@ -75,7 +75,7 @@ public class WatchTest {
   @Test(dependsOnMethods = "testWatch")
   public void testWatchPut() throws InterruptedException {
     kvClient
-        .put(Util.byteStringFromByteSequence(key), Util.byteStringFromByteSequence(value));
+        .put(key, value);
     WatchEvent event = eventsQueue.poll(5, TimeUnit.SECONDS);
     test.assertEquals(event.getKeyValue().getKey(), key);
     test.assertEquals(event.getEventType(), WatchEvent.EventType.PUT);
@@ -87,7 +87,7 @@ public class WatchTest {
    */
   @Test(dependsOnMethods = "testWatchPut")
   public void testWatchDelete() throws InterruptedException {
-    kvClient.delete(Util.byteStringFromByteSequence(key));
+    kvClient.delete(key);
     WatchEvent event = eventsQueue.poll(5, TimeUnit.SECONDS);
     test.assertEquals(event.getKeyValue().getKey(), key);
     test.assertEquals(event.getEventType(), WatchEvent.EventType.DELETE);

--- a/src/test/java/com/coreos/jetcd/op/TxnTest.java
+++ b/src/test/java/com/coreos/jetcd/op/TxnTest.java
@@ -1,15 +1,15 @@
 package com.coreos.jetcd.op;
 
+import com.coreos.jetcd.data.ByteSequence;
 import com.coreos.jetcd.options.PutOption;
-import com.google.protobuf.ByteString;
 import org.testng.annotations.Test;
 
 public class TxnTest {
 
-  final Cmp CMP = new Cmp(ByteString.copyFromUtf8("key"), Cmp.Op.GREATER,
-      CmpTarget.value(ByteString.copyFromUtf8("value")));
+  final Cmp CMP = new Cmp(ByteSequence.fromString("key"), Cmp.Op.GREATER,
+      CmpTarget.value(ByteSequence.fromString("value")));
   final Op OP = Op
-      .put(ByteString.copyFromUtf8("key2"), ByteString.copyFromUtf8("value2"), PutOption.DEFAULT);
+      .put(ByteSequence.fromString("key2"), ByteSequence.fromString("value2"), PutOption.DEFAULT);
 
   @Test
   public void testIfs() {


### PR DESCRIPTION
exposed APIs should take ByteSequence instead of ByteString as the argument type.
In this way, jetcd APIs doesn't depend on Guava ByteString.