### PR TITLE
Lease: refactor lease APIs to take client side response

### DIFF
--- a/src/main/java/com/coreos/jetcd/Lease.java
+++ b/src/main/java/com/coreos/jetcd/Lease.java
@@ -1,8 +1,9 @@
 package com.coreos.jetcd;
 
-import com.coreos.jetcd.api.LeaseGrantResponse;
 import com.coreos.jetcd.api.LeaseKeepAliveResponse;
-import com.coreos.jetcd.api.LeaseRevokeResponse;
+import com.coreos.jetcd.lease.LeaseGrantResponse;
+import com.coreos.jetcd.lease.LeaseRevokeResponse;
+import com.coreos.jetcd.lease.LeaseTimeToLiveResponse;
 import com.coreos.jetcd.lease.NoSuchLeaseException;
 import com.coreos.jetcd.options.LeaseOption;
 import java.util.concurrent.CompletableFuture;
@@ -48,7 +49,7 @@ public interface Lease {
    * @param leaseId id of lease to keep alive once
    * @return The keep alive response
    */
-  CompletableFuture<LeaseKeepAliveResponse> keepAliveOnce(long leaseId);
+  CompletableFuture<com.coreos.jetcd.lease.LeaseKeepAliveResponse> keepAliveOnce(long leaseId);
 
   /**
    * retrieves the lease information of the given lease ID.
@@ -57,7 +58,7 @@ public interface Lease {
    * @param leaseOption LeaseOption
    * @return LeaseTimeToLiveResponse wrapped in CompletableFuture
    */
-  CompletableFuture<com.coreos.jetcd.lease.LeaseTimeToLiveResponse> timeToLive(long leaseId,
+  CompletableFuture<LeaseTimeToLiveResponse> timeToLive(long leaseId,
       LeaseOption leaseOption);
 
   /**

--- a/src/main/java/com/coreos/jetcd/WatchImpl.java
+++ b/src/main/java/com/coreos/jetcd/WatchImpl.java
@@ -1,7 +1,7 @@
 package com.coreos.jetcd;
 
-import static com.coreos.jetcd.Util.apiToClientEvents;
-import static com.coreos.jetcd.Util.apiToClientHeader;
+import static com.coreos.jetcd.Util.toEvents;
+import static com.coreos.jetcd.Util.toHeader;
 
 import com.coreos.jetcd.api.Event;
 import com.coreos.jetcd.api.WatchCancelRequest;
@@ -173,14 +173,14 @@ public class WatchImpl implements Watch {
         watcher.setCanceled(true);
         requestPair.getValue().completeExceptionally(
             new WatchCreateException("the start revision has been compacted",
-                apiToClientHeader(response.getHeader(), response.getCompactRevision())));
+                toHeader(response.getHeader(), response.getCompactRevision())));
         ;
       }
 
       if (response.getWatchId() == -1 && watcher.callback != null) {
         requestPair.getValue().completeExceptionally(
             new WatchCreateException("create watcher failed",
-                apiToClientHeader(response.getHeader(), response.getCompactRevision())));
+                toHeader(response.getHeader(), response.getCompactRevision())));
       } else {
         this.watchers.put(watcher.getWatchID(), watcher);
         watcher.setWatchID(response.getWatchId());
@@ -224,8 +224,8 @@ public class WatchImpl implements Watch {
 
           if (watcher.callback != null) {
             watcher.callback.onWatch(
-                apiToClientHeader(watchResponse.getHeader(), watchResponse.getCompactRevision()),
-                apiToClientEvents(events));
+                toHeader(watchResponse.getHeader(), watchResponse.getCompactRevision()),
+                toEvents(events));
           }
         } else {
           watcher.setLastRevision(watchResponse.getHeader().getRevision());

--- a/src/main/java/com/coreos/jetcd/lease/LeaseGrantResponse.java
+++ b/src/main/java/com/coreos/jetcd/lease/LeaseGrantResponse.java
@@ -1,0 +1,34 @@
+package com.coreos.jetcd.lease;
+
+import com.coreos.jetcd.data.Header;
+
+public class LeaseGrantResponse {
+
+  private Header header;
+  private long leaseId;
+  private long ttl;
+
+  public LeaseGrantResponse(Header header, long leaseId, long ttl) {
+    this.header = header;
+    this.leaseId = leaseId;
+    this.ttl = ttl;
+  }
+
+  public Header getHeader() {
+    return header;
+  }
+
+  /**
+   * ID is the lease ID for the granted lease.
+   */
+  public long getID() {
+    return leaseId;
+  }
+
+  /**
+   * TTL is the server chosen lease time-to-live in seconds.
+   */
+  public long getTTL() {
+    return ttl;
+  }
+}

--- a/src/main/java/com/coreos/jetcd/lease/LeaseKeepAliveResponse.java
+++ b/src/main/java/com/coreos/jetcd/lease/LeaseKeepAliveResponse.java
@@ -1,0 +1,34 @@
+package com.coreos.jetcd.lease;
+
+import com.coreos.jetcd.data.Header;
+
+public class LeaseKeepAliveResponse {
+
+  private Header header;
+  private long leaseId;
+  private long ttl;
+
+  public LeaseKeepAliveResponse(Header header, long leaseId, long ttl) {
+    this.header = header;
+    this.leaseId = leaseId;
+    this.ttl = ttl;
+  }
+
+  public Header getHeader() {
+    return header;
+  }
+
+  /**
+   * ID is the lease ID from the keep alive request.
+   */
+  public long getID() {
+    return leaseId;
+  }
+
+  /**
+   * TTL is the new time-to-live for the lease.
+   */
+  public long getTTL() {
+    return ttl;
+  }
+}

--- a/src/main/java/com/coreos/jetcd/lease/LeaseRevokeResponse.java
+++ b/src/main/java/com/coreos/jetcd/lease/LeaseRevokeResponse.java
@@ -1,0 +1,16 @@
+package com.coreos.jetcd.lease;
+
+import com.coreos.jetcd.data.Header;
+
+public class LeaseRevokeResponse {
+
+  private Header header;
+
+  public LeaseRevokeResponse(Header header) {
+    this.header = header;
+  }
+
+  public Header getHeader() {
+    return header;
+  }
+}

--- a/src/main/java/com/coreos/jetcd/lease/LeaseTimeToLiveResponse.java
+++ b/src/main/java/com/coreos/jetcd/lease/LeaseTimeToLiveResponse.java
@@ -25,18 +25,31 @@ public class LeaseTimeToLiveResponse {
     return header;
   }
 
-  public long getLeaseId() {
+  /**
+   * ID is the lease ID from the keep alive request.
+   */
+  public long getID() {
     return leaseId;
   }
 
+  /**
+   * TTL is the remaining TTL in seconds for the lease;
+   * the lease will expire in under TTL+1 seconds.
+   */
   public long getTTl() {
     return ttl;
   }
 
+  /**
+   * GrantedTTL is the initial granted time in seconds upon lease creation/renewal.
+   */
   public long getGrantedTTL() {
     return grantedTtl;
   }
 
+  /**
+   * Keys is the list of keys attached to this lease.
+   */
   public List<ByteSequence> getKeys() {
     return keys;
   }

--- a/src/test/java/com/coreos/jetcd/LeaseTest.java
+++ b/src/test/java/com/coreos/jetcd/LeaseTest.java
@@ -63,7 +63,7 @@ public class LeaseTest {
     long leaseID = leaseClient.grant(2).get().getID();
     kvClient.put(KEY, VALUE, PutOption.newBuilder().withLeaseId(leaseID).build()).get();
     test.assertEquals(kvClient.get(KEY).get().getCount(), 1);
-    LeaseKeepAliveResponse rp = leaseClient.keepAliveOnce(leaseID).get();
+    com.coreos.jetcd.lease.LeaseKeepAliveResponse rp = leaseClient.keepAliveOnce(leaseID).get();
     assertThat(rp.getTTL()).isGreaterThan(0);
   }
 

--- a/src/test/java/com/coreos/jetcd/LeaseUnitTest.java
+++ b/src/test/java/com/coreos/jetcd/LeaseUnitTest.java
@@ -10,8 +10,6 @@ import com.coreos.jetcd.api.LeaseKeepAliveRequest;
 import com.coreos.jetcd.api.LeaseKeepAliveResponse;
 import com.coreos.jetcd.exception.AuthFailedException;
 import com.coreos.jetcd.exception.ConnectException;
-import com.coreos.jetcd.lease.LeaseTimeToLiveResponse;
-import com.coreos.jetcd.options.LeaseOption;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcServerRule;
@@ -59,30 +57,33 @@ public class LeaseUnitTest {
 
   @Test(timeout = 1000)
   public void testKeepAliveOnce() throws ExecutionException, InterruptedException {
-    CompletableFuture<LeaseKeepAliveResponse> lrpFuture = this.leaseCli.keepAliveOnce(LEASE_ID);
+    CompletableFuture<com.coreos.jetcd.lease.LeaseKeepAliveResponse> lrpFuture = this.leaseCli
+        .keepAliveOnce(LEASE_ID);
     LeaseKeepAliveResponse lrp = LeaseKeepAliveResponse
         .newBuilder()
         .setID(LEASE_ID)
         .build();
     this.responseObserverRef.get().onNext(lrp);
 
-    LeaseKeepAliveResponse lrpActual = lrpFuture.get();
-    assertThat(lrpActual).isEqualTo(lrp);
+    com.coreos.jetcd.lease.LeaseKeepAliveResponse lrpActual = lrpFuture.get();
+    assertThat(lrpActual.getID()).isEqualTo(lrp.getID());
   }
 
   @Test(timeout = 1000)
   public void testKeepAliveOnceConnectError() throws ExecutionException, InterruptedException {
-    CompletableFuture<LeaseKeepAliveResponse> lrpFuture = this.leaseCli.keepAliveOnce(LEASE_ID);
+    CompletableFuture<com.coreos.jetcd.lease.LeaseKeepAliveResponse> lrpFuture = this.leaseCli
+        .keepAliveOnce(LEASE_ID);
     Throwable t = Status.ABORTED.asRuntimeException();
     responseObserverRef.get().onError(t);
-    
+
     assertThatThrownBy(() -> lrpFuture.get()).hasCause(t);
   }
 
   @Test(timeout = 1000)
   public void testKeepAliveOnceStreamCloseOnSuccess()
       throws ExecutionException, InterruptedException {
-    CompletableFuture<LeaseKeepAliveResponse> lrpFuture = this.leaseCli.keepAliveOnce(LEASE_ID);
+    CompletableFuture<com.coreos.jetcd.lease.LeaseKeepAliveResponse> lrpFuture = this.leaseCli
+        .keepAliveOnce(LEASE_ID);
     LeaseKeepAliveResponse lrp = LeaseKeepAliveResponse
         .newBuilder()
         .setID(LEASE_ID)


### PR DESCRIPTION
hide grpc response from user by return client side response.
use listenableToCompletableFuture() instead of FutureConverter.toCompletableFuture() for convert listenable future.
minor refactoring on util and watch


