### PR TITLE
watch: range optional returns null if it is empty 

### DIFF
--- a/src/main/java/com/coreos/jetcd/WatchImpl.java
+++ b/src/main/java/com/coreos/jetcd/WatchImpl.java
@@ -296,7 +296,7 @@ public class WatchImpl implements Watch {
         .withNoPut(oldOption.isNoPut())
         .withPrevKV(oldOption.isPrevKV())
         .withProgressNotify(oldOption.isProgressNotify())
-        .withRange(oldOption.getEndKey().get())
+        .withRange(oldOption.getEndKey().orElse(null))
         .withRevision(watcher.getLastRevision() + 1)
         .withResuming(true)
         .build();


### PR DESCRIPTION
emptyOptional.get() throws java.util.NoSuchElementException: No value present if optional is empty.
instead emptyOptional.orElse(null) returns null if its empty.

Fixes #125