### PR TITLE
proto: update rpc.proto at etcd f7df3c80d5d9fe4782cfb28c01a3c9bf766a15aa

### DIFF
--- a/src/main/proto/rpc.proto
+++ b/src/main/proto/rpc.proto
@@ -180,7 +180,8 @@ message RangeRequest {
   // then the range request gets all keys prefixed with key.
   // If both key and range_end are '\0', then the range request returns all keys.
   bytes range_end = 2;
-  // limit is a limit on the number of keys returned for the request.
+  // limit is a limit on the number of keys returned for the request. When limit is set to 0,
+  // it is treated as no limit.
   int64 limit = 3;
   // revision is the point-in-time of the key-value store to use for the range.
   // If revision is less or equal to zero, the range is over the newest key-value store.
@@ -268,13 +269,13 @@ message DeleteRangeRequest {
   bytes key = 1;
   // range_end is the key following the last key to delete for the range [key, range_end).
   // If range_end is not given, the range is defined to contain only the key argument.
-  // If range_end is one bit larger than the given key, then the range is all
-  // the all keys with the prefix (the given key).
+  // If range_end is one bit larger than the given key, then the range is all the keys
+  // with the prefix (the given key).
   // If range_end is '\0', the range is all keys greater than or equal to the key argument.
   bytes range_end = 2;
 
   // If prev_kv is set, etcd gets the previous key-value pairs before deleting it.
-  // The previous key-value pairs will be returned in the delte response.
+  // The previous key-value pairs will be returned in the delete response.
   bool prev_kv = 3;
 }
 
@@ -292,6 +293,7 @@ message RequestOp {
     RangeRequest request_range = 1;
     PutRequest request_put = 2;
     DeleteRangeRequest request_delete_range = 3;
+    TxnRequest request_txn = 4;
   }
 }
 
@@ -301,6 +303,7 @@ message ResponseOp {
     RangeResponse response_range = 1;
     PutResponse response_put = 2;
     DeleteRangeResponse response_delete_range = 3;
+    TxnResponse response_txn = 4;
   }
 }
 
@@ -333,6 +336,10 @@ message Compare {
     // value is the value of the given key, in bytes.
     bytes value = 7;
   }
+  // range_end compares the given target to all keys in the range [key, range_end).
+  // See RangeRequest for more details on key ranges.
+  bytes range_end = 8;
+  // TODO: fill out with most of the rest of RangeRequest fields when needed.
 }
 
 // From google paxosdb paper:
@@ -477,6 +484,9 @@ message WatchResponse {
   // watcher with the same start_revision again.
   int64 compact_revision  = 5;
 
+  // cancel_reason indicates the reason for canceling the watcher.
+  string cancel_reason = 6;
+
   repeated mvccpb.Event events = 11;
 }
 
@@ -557,6 +567,8 @@ message MemberAddResponse {
   ResponseHeader header = 1;
   // member is the member information for the added member.
   Member member = 2;
+  // members is a list of all members after adding the new member.
+  repeated Member members = 3;
 }
 
 message MemberRemoveRequest {
@@ -566,6 +578,8 @@ message MemberRemoveRequest {
 
 message MemberRemoveResponse {
   ResponseHeader header = 1;
+  // members is a list of all members after removing the member.
+  repeated Member members = 2;
 }
 
 message MemberUpdateRequest {
@@ -577,6 +591,8 @@ message MemberUpdateRequest {
 
 message MemberUpdateResponse{
   ResponseHeader header = 1;
+  // members is a list of all members after updating the member.
+  repeated Member members = 2;
 }
 
 message MemberListRequest {


### PR DESCRIPTION
updated rpc.proto allows java client to implement nested txn and retrieve cancel_reason field from watch response.