### PR TITLE
pom: disable building jetcd-all for release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,6 @@
 
     <modules>
         <module>jetcd-core</module>
-        <module>jetcd-all</module>
         <module>jetcd-examples</module>
     </modules>
 


### PR DESCRIPTION
maven shade plugin can't generate java doc jar for jetcd-all which is
required for uploading to maven central.