### PR TITLE
pom: remove parent pom dependency for examples

### DIFF
--- a/jetcd-examples/jetcd-simple-ctl/pom.xml
+++ b/jetcd-examples/jetcd-simple-ctl/pom.xml
@@ -20,43 +20,44 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-  <parent>
-    <groupId>com.coreos</groupId>
-    <artifactId>jetcd-examples</artifactId>
-    <version>0.0.1</version>
-  </parent>
-
   <modelVersion>4.0.0</modelVersion>
+  <groupId>com.coreos</groupId>
   <artifactId>jetcd-simple-ctl</artifactId>
+  <version>0.0.1</version>
   <packaging>jar</packaging>
 
   <dependencies>
     <dependency>
       <groupId>com.coreos</groupId>
       <artifactId>jetcd-core</artifactId>
-      <version>${project.version}</version>
+      <version>0.0.1</version>
     </dependency>
 
     <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
+      <version>1.72</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
+      <version>2.8.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
+      <version>2.8.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
+      <version>2.8.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-1.2-api</artifactId>
+      <version>2.8.2</version>
     </dependency>
   </dependencies>
 
@@ -64,7 +65,17 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.6.2</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <version>3.0.0</version>
         <configuration>
           <finalName>jetcdctl</finalName>
         </configuration>

--- a/jetcd-examples/jetcd-watch-example/pom.xml
+++ b/jetcd-examples/jetcd-watch-example/pom.xml
@@ -20,44 +20,44 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <parent>
-        <groupId>com.coreos</groupId>
-        <artifactId>jetcd-examples</artifactId>
-        <version>0.0.1</version>
-    </parent>
-
     <modelVersion>4.0.0</modelVersion>
+    <groupId>com.coreos</groupId>
     <artifactId>jetcd-watch-example</artifactId>
+    <version>0.0.1</version>
     <packaging>jar</packaging>
-
 
     <dependencies>
         <dependency>
             <groupId>com.coreos</groupId>
             <artifactId>jetcd-core</artifactId>
-            <version>${project.version}</version>
+            <version>0.0.1</version>
         </dependency>
 
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
+            <version>1.72</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
+            <version>2.8.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
+            <version>2.8.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.8.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-1.2-api</artifactId>
+            <version>2.8.2</version>
         </dependency>
     </dependencies>
 
@@ -66,14 +66,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.6.2</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
                 <executions>
                     <execution>
                         <goals>

--- a/jetcd-examples/pom.xml
+++ b/jetcd-examples/pom.xml
@@ -20,14 +20,10 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <parent>
-        <groupId>com.coreos</groupId>
-        <artifactId>jetcd-parent</artifactId>
-        <version>0.0.1</version>
-    </parent>
-
     <modelVersion>4.0.0</modelVersion>
+    <groupId>com.coreos</groupId>
     <artifactId>jetcd-examples</artifactId>
+    <version>0.0.1</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
examples should have independent pom configuration that doesn't depend on jetcd-parent 