### PR TITLE
GG-489/#246 add lock support

### DIFF
--- a/jetcd-core/src/main/java/com/coreos/jetcd/Lock.java
+++ b/jetcd-core/src/main/java/com/coreos/jetcd/Lock.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2017 The jetcd authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.coreos.jetcd;
+
+import com.coreos.jetcd.data.ByteSequence;
+import com.coreos.jetcd.internal.impl.CloseableClient;
+import com.coreos.jetcd.lock.LockResponse;
+import com.coreos.jetcd.lock.UnlockResponse;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Interface of Lock talking to etcd.
+ */
+public interface Lock extends CloseableClient {
+
+  /**
+   * Acquire a lock with the given name.
+   *
+   * @param name
+   *          the identifier for the distributed shared lock to be acquired.
+   * @param leaseId
+   *          the ID of the lease that will be attached to ownership of the
+   *          lock. If the lease expires or is revoked and currently holds the
+   *          lock, the lock is automatically released. Calls to Lock with the
+   *          same lease will be treated as a single acquistion; locking twice
+   *          with the same lease is a no-op.
+   */
+  CompletableFuture<LockResponse> lock(ByteSequence name, long leaseId);
+
+  /**
+   * Release the lock identified by the given key.
+   *
+   * @param lockKey
+   *          key is the lock ownership key granted by Lock.
+   */
+  CompletableFuture<UnlockResponse> unlock(ByteSequence lockKey);
+
+}

--- a/jetcd-core/src/main/java/com/coreos/jetcd/data/ByteSequence.java
+++ b/jetcd-core/src/main/java/com/coreos/jetcd/data/ByteSequence.java
@@ -67,7 +67,7 @@ public class ByteSequence {
     }
   }
 
-  protected ByteString getByteString() {
+  public ByteString getByteString() {
     return this.byteString;
   }
 
@@ -116,7 +116,7 @@ public class ByteSequence {
     return new ByteSequence(charBuffer);
   }
 
-  protected static ByteSequence fromByteString(ByteString byteString) {
+  public static ByteSequence fromByteString(ByteString byteString) {
     return new ByteSequence(byteString);
   }
 

--- a/jetcd-core/src/main/java/com/coreos/jetcd/internal/impl/ClientImpl.java
+++ b/jetcd-core/src/main/java/com/coreos/jetcd/internal/impl/ClientImpl.java
@@ -22,6 +22,7 @@ import com.coreos.jetcd.ClientBuilder;
 import com.coreos.jetcd.Cluster;
 import com.coreos.jetcd.KV;
 import com.coreos.jetcd.Lease;
+import com.coreos.jetcd.Lock;
 import com.coreos.jetcd.Maintenance;
 import com.coreos.jetcd.Watch;
 import java.util.Optional;
@@ -39,6 +40,7 @@ public final class ClientImpl implements Client {
   private final AtomicReference<Cluster> clusterClient;
   private final AtomicReference<Lease> leaseClient;
   private final AtomicReference<Watch> watchClient;
+  private final AtomicReference<Lock> lockClient;
   private final ClientBuilder builder;
   private final ClientConnectionManager connectionManager;
 
@@ -52,6 +54,7 @@ public final class ClientImpl implements Client {
     this.clusterClient = new AtomicReference<>();
     this.leaseClient = new AtomicReference<>();
     this.watchClient = new AtomicReference<>();
+    this.lockClient = new AtomicReference<>();
     this.connectionManager = new ClientConnectionManager(this.builder);
 
     // If the client is not configured to be lazy, set up the managed connection and perform
@@ -92,6 +95,11 @@ public final class ClientImpl implements Client {
   }
 
   @Override
+  public Lock getLockClient() {
+    return newClient(lockClient, LockImpl::new);
+  }
+
+  @Override
   public synchronized void close() {
     Optional.ofNullable(authClient.get()).ifPresent(CloseableClient::close);
     Optional.ofNullable(kvClient.get()).ifPresent(CloseableClient::close);
@@ -99,6 +107,7 @@ public final class ClientImpl implements Client {
     Optional.ofNullable(maintenanceClient.get()).ifPresent(CloseableClient::close);
     Optional.ofNullable(leaseClient.get()).ifPresent(CloseableClient::close);
     Optional.ofNullable(watchClient.get()).ifPresent(CloseableClient::close);
+    Optional.ofNullable(lockClient.get()).ifPresent(CloseableClient::close);
 
     connectionManager.close();
   }

--- a/jetcd-core/src/main/java/com/coreos/jetcd/internal/impl/LockImpl.java
+++ b/jetcd-core/src/main/java/com/coreos/jetcd/internal/impl/LockImpl.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2017 The jetcd authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.coreos.jetcd.internal.impl;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.coreos.jetcd.Lock;
+import com.coreos.jetcd.api.lock.LockGrpc;
+import com.coreos.jetcd.api.lock.LockRequest;
+import com.coreos.jetcd.api.lock.UnlockRequest;
+import com.coreos.jetcd.data.ByteSequence;
+import com.coreos.jetcd.lock.LockResponse;
+import com.coreos.jetcd.lock.UnlockResponse;
+import java.util.concurrent.CompletableFuture;
+
+class LockImpl implements Lock {
+
+  private final ClientConnectionManager connectionManager;
+
+  private final LockGrpc.LockFutureStub stub;
+
+  LockImpl(ClientConnectionManager connectionManager) {
+    this.connectionManager = connectionManager;
+    this.stub = connectionManager.newStub(LockGrpc::newFutureStub);
+  }
+
+  @Override
+  public CompletableFuture<LockResponse> lock(ByteSequence name, long leaseId) {
+    checkNotNull(name);
+    LockRequest request = LockRequest.newBuilder()
+        .setName(name.getByteString())
+        .setLease(leaseId)
+        .build();
+
+    return Util.toCompletableFutureWithRetry(
+        () -> stub.lock(request),
+        LockResponse::new,
+        Util::isRetriable,
+        connectionManager.getExecutorService()
+    );
+  }
+
+  @Override
+  public CompletableFuture<UnlockResponse> unlock(ByteSequence lockKey) {
+    checkNotNull(lockKey);
+    UnlockRequest request = UnlockRequest.newBuilder()
+        .setKey(lockKey.getByteString())
+        .build();
+
+    return Util.toCompletableFutureWithRetry(
+        () -> stub.unlock(request),
+        UnlockResponse::new,
+        Util::isRetriable,
+        connectionManager.getExecutorService()
+    );
+  }
+}

--- a/jetcd-core/src/main/java/com/coreos/jetcd/lock/LockResponse.java
+++ b/jetcd-core/src/main/java/com/coreos/jetcd/lock/LockResponse.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2017 The jetcd authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.coreos.jetcd.lock;
+
+import com.coreos.jetcd.data.AbstractResponse;
+import com.coreos.jetcd.data.ByteSequence;
+
+public class LockResponse extends AbstractResponse<com.coreos.jetcd.api.lock.LockResponse> {
+
+  public LockResponse(com.coreos.jetcd.api.lock.LockResponse response) {
+    super(response, response.getHeader());
+  }
+
+  /**
+   * key is a key that will exist on etcd for the duration that the Lock caller
+   * owns the lock. Users should not modify this key or the lock may exhibit
+   * undefined behavior.
+   */
+  public ByteSequence getKey() {
+    return ByteSequence.fromByteString(getResponse().getKey());
+  }
+
+}

--- a/jetcd-core/src/main/java/com/coreos/jetcd/lock/UnlockResponse.java
+++ b/jetcd-core/src/main/java/com/coreos/jetcd/lock/UnlockResponse.java
@@ -14,34 +14,14 @@
  * limitations under the License.
  */
 
-package com.coreos.jetcd;
+package com.coreos.jetcd.lock;
 
-/**
- * Etcd Client.
- *
- * <p>The implementation may throw unchecked ConnectException or AuthFailedException on
- *    initialization (or when invoking *Client methods if configured to initialize lazily).
- */
-public interface Client extends AutoCloseable {
+import com.coreos.jetcd.data.AbstractResponse;
 
-  Auth getAuthClient();
+public class UnlockResponse extends AbstractResponse<com.coreos.jetcd.api.lock.UnlockResponse> {
 
-  KV getKVClient();
-
-  Cluster getClusterClient();
-
-  Maintenance getMaintenanceClient();
-
-  Lease getLeaseClient();
-
-  Watch getWatchClient();
-
-  Lock getLockClient();
-
-  @Override
-  void close();
-
-  static ClientBuilder builder() {
-    return new ClientBuilder();
+  public UnlockResponse(com.coreos.jetcd.api.lock.UnlockResponse response) {
+    super(response, response.getHeader());
   }
+
 }

--- a/jetcd-core/src/main/proto/lock.proto
+++ b/jetcd-core/src/main/proto/lock.proto
@@ -1,0 +1,70 @@
+//
+// Copyright 2017 The jetcd authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+import "rpc.proto";
+
+package v3lockpb;
+
+option java_multiple_files = true;
+option java_package = "com.coreos.jetcd.api.lock";
+option java_outer_classname = "JetcdProto";
+option objc_class_prefix = "Jetcd";
+
+// The lock service exposes client-side locking facilities as a gRPC interface.
+service Lock {
+    // Lock acquires a distributed shared lock on a given named lock.
+    // On success, it will return a unique key that exists so long as the
+    // lock is held by the caller. This key can be used in conjunction with
+    // transactions to safely ensure updates to etcd only occur while holding
+    // lock ownership. The lock is held until Unlock is called on the key or the
+    // lease associate with the owner expires.
+    rpc Lock(LockRequest) returns (LockResponse) {}
+
+    // Unlock takes a key returned by Lock and releases the hold on lock. The
+    // next Lock caller waiting for the lock will then be woken up and given
+    // ownership of the lock.
+    rpc Unlock(UnlockRequest) returns (UnlockResponse) {}
+}
+
+message LockRequest {
+    // name is the identifier for the distributed shared lock to be acquired.
+    bytes name = 1;
+    // lease is the ID of the lease that will be attached to ownership of the
+    // lock. If the lease expires or is revoked and currently holds the lock,
+    // the lock is automatically released. Calls to Lock with the same lease will
+    // be treated as a single acquistion; locking twice with the same lease is a
+    // no-op.
+    int64 lease = 2;
+}
+
+message LockResponse {
+    etcdserverpb.ResponseHeader header = 1;
+    // key is a key that will exist on etcd for the duration that the Lock caller
+    // owns the lock. Users should not modify this key or the lock may exhibit
+    // undefined behavior.
+    bytes key = 2;
+}
+
+message UnlockRequest {
+    // key is the lock ownership key granted by Lock.
+    bytes key = 1;
+}
+
+message UnlockResponse {
+    etcdserverpb.ResponseHeader header = 1;
+}

--- a/jetcd-core/src/test/java/com/coreos/jetcd/internal/impl/LockTest.java
+++ b/jetcd-core/src/test/java/com/coreos/jetcd/internal/impl/LockTest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2017 The jetcd authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.coreos.jetcd.internal.impl;
+
+import com.coreos.jetcd.*;
+import com.coreos.jetcd.data.ByteSequence;
+import com.coreos.jetcd.lease.LeaseGrantResponse;
+import com.coreos.jetcd.lock.LockResponse;
+import org.testng.annotations.*;
+import org.testng.asserts.Assertion;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Lock service test cases.
+ */
+public class LockTest {
+
+  private Lock lockClient;
+  private Lease leaseClient;
+  private Assertion test;
+  private Set<ByteSequence> locksToRelease;
+
+  private static final ByteSequence SAMPLE_NAME = ByteSequence.fromString("sample_name");
+
+  @BeforeTest
+  public void setUp() throws Exception {
+    test = new Assertion();
+    Client client = Client.builder().endpoints(TestConstants.endpoints).build();
+    lockClient = client.getLockClient();
+    leaseClient = client.getLeaseClient();
+    locksToRelease = new HashSet<>();
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    for (ByteSequence lockKey : locksToRelease) {
+      lockClient.unlock(lockKey).get();
+    }
+    locksToRelease.clear();
+  }
+
+  @Test
+  public void testLockWithoutLease() throws Exception {
+    CompletableFuture<LockResponse> feature = lockClient.lock(SAMPLE_NAME, 0);
+    LockResponse response = feature.get();
+    locksToRelease.add(response.getKey());
+    test.assertTrue(response.getHeader() != null);
+    test.assertTrue(response.getKey() != null);
+  }
+
+  @Test(expectedExceptions = ExecutionException.class,
+          expectedExceptionsMessageRegExp = ".*etcdserver: requested lease not found")
+  public void testLockWithNotExistingLease() throws Exception {
+    CompletableFuture<LockResponse> feature = lockClient.lock(SAMPLE_NAME, 123456);
+    LockResponse response = feature.get();
+    locksToRelease.add(response.getKey());
+  }
+
+  @Test
+  public void testLockWithLease() throws Exception {
+    long lease = grantLease(20);
+
+    CompletableFuture<LockResponse> feature = lockClient.lock(SAMPLE_NAME, lease);
+    LockResponse response = feature.get();
+
+    long currentMillis = System.currentTimeMillis();
+
+    CompletableFuture<LockResponse> feature2 = lockClient.lock(SAMPLE_NAME, 0);
+    LockResponse response2 = feature2.get();
+
+    long time = System.currentTimeMillis() - currentMillis;
+
+    test.assertNotEquals(response.getKey(), response2.getKey());
+    test.assertTrue(time >= 19500 && time <= 21000,
+            String.format("Lease not runned out after 20000ms, was %dms", time));
+
+    locksToRelease.add(response.getKey());
+    locksToRelease.add(response2.getKey());
+  }
+
+  @Test
+  public void testLockWithUnlock() throws Exception {
+    long lease = grantLease(20);
+    CompletableFuture<LockResponse> feature = lockClient.lock(SAMPLE_NAME, lease);
+    LockResponse response = feature.get();
+
+    Thread.sleep(5000);
+
+    lockClient.unlock(response.getKey()).get();
+
+    long currentMillis = System.currentTimeMillis();
+
+    CompletableFuture<LockResponse> feature2 = lockClient.lock(SAMPLE_NAME, 0);
+    LockResponse response2 = feature2.get();
+
+    long time = System.currentTimeMillis() - currentMillis;
+
+    test.assertNotEquals(response.getKey(), response2.getKey());
+    test.assertTrue(time <= 500,
+            String.format("Lease not unlocked, wait time was too long (%dms)", time));
+
+    locksToRelease.add(response2.getKey());
+  }
+
+  private long grantLease(long ttl) throws Exception {
+    CompletableFuture<LeaseGrantResponse> feature = leaseClient.grant(ttl);
+    LeaseGrantResponse response = feature.get();
+    return response.getID();
+  }
+
+}


### PR DESCRIPTION
I added a lock client which supports the API of the etcd lock service ([doc](https://github.com/coreos/etcd/blob/master/Documentation/dev-guide/api_concurrency_reference_v3.md#service-lock-etcdserverapiv3lockv3lockpbv3lockproto))

fixes #246 