### PR TITLE
examples: skip release for for examples and jetcd-all

### DIFF
--- a/jetcd-examples/jetcd-simple-ctl/pom.xml
+++ b/jetcd-examples/jetcd-simple-ctl/pom.xml
@@ -100,6 +100,15 @@
           </archive>
         </configuration>
       </plugin>
+      <!-- do not deploy simple-ctl -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.8.2</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/jetcd-examples/jetcd-watch-example/pom.xml
+++ b/jetcd-examples/jetcd-watch-example/pom.xml
@@ -93,6 +93,15 @@
                     </arguments>
                 </configuration>
             </plugin>
+            <!-- do not deploy watch-example -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/jetcd-examples/pom.xml
+++ b/jetcd-examples/pom.xml
@@ -31,4 +31,20 @@
         <module>jetcd-simple-ctl</module>
     </modules>
 
+    <build>
+    <plugins>
+        <!-- do not deploy examples -->
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <version>2.8.2</version>
+            <configuration>
+                <skip>true</skip>
+            </configuration>
+        </plugin>
+    </plugins>
+    </build>
+
+
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,9 @@
         <module>jetcd-resolver</module>
         <module>jetcd-resolver-dns-srv</module>
         <module>jetcd-core</module>
+        <!-- disable jetcd-all for release due to lacking javadoc
         <module>jetcd-all</module>
+        -->
         <module>jetcd-osgi</module>
         <module>jetcd-examples</module>
     </modules>


### PR DESCRIPTION
skip examples and jetcd-all when publish snapshots and final release.
can't generate java doc for jetcd-all due to issue with shading.
can't generate snapshot for example which block 0.0.2 release.

for now, we can skip examples and jetcd-all pkg for 0.0.2 release.