### PR TITLE
eclipse: add M2E lifecycle mapping to ignore directory-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -538,6 +538,31 @@
                     <version>${exec-maven-plugin.version}</version>
                 </plugin>
 
+                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+                <plugin>
+                  <groupId>org.eclipse.m2e</groupId>
+                  <artifactId>lifecycle-mapping</artifactId>
+                  <version>1.0.0</version>
+                  <configuration>
+                    <lifecycleMappingMetadata>
+                      <pluginExecutions>
+                        <pluginExecution>
+                          <pluginExecutionFilter>
+                            <groupId>org.commonjava.maven.plugins</groupId>
+                            <artifactId>directory-maven-plugin</artifactId>
+                            <versionRange>[0.3.1,)</versionRange>
+                            <goals>
+                              <goal>highest-basedir</goal>
+                            </goals>
+                          </pluginExecutionFilter>
+                          <action>
+                            <ignore></ignore>
+                          </action>
+                        </pluginExecution>
+                      </pluginExecutions>
+                    </lifecycleMappingMetadata>
+                  </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
 


### PR DESCRIPTION
re. https://github.com/coreos/jetcd/issues/340 (but not fixed, yet)